### PR TITLE
[docs] Add RSS feed.xml for blog posts

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,7 @@
 ---
 markdown: redcarpet
 name: React
+description: A JavaScript library for building user interfaces
 redcarpet:
   extensions:
   - fenced_code_blocks
@@ -11,4 +12,5 @@ exclude:
 - Gemfile.lock
 - README.md
 - Rakefile
+url: http://facebook.github.io
 baseurl: /react

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -12,6 +12,7 @@
   <meta property="og:description" content="A JavaScript library for building user interfaces" />
 
   <link rel="shortcut icon" href="/react/favicon.ico">
+  <link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="{{ site.url }}{{ site.baseurl }}/feed.xml">
 
   <link rel="stylesheet" href="/react/css/react.css">
   <link rel="stylesheet" href="/react/css/syntax.css">

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -1,0 +1,21 @@
+---
+layout: none
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+	<channel>
+		<title>{{ site.name }}</title>
+		<description>{{ site.description }}</description>
+		<link>{{ site.url }}{{ site.baseurl }}</link>
+		<atom:link href="{{ site.url }}{{ site.baseurl }}/feed.xml" rel="self" type="application/rss+xml" />
+		{% for post in site.posts limit:10 %}
+			<item>
+				<title>{{ post.title }}</title>
+				<description>{{ post.content | xml_escape }}</description>
+				<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+				<link>{{ site.url }}{{ site.baseurl }}{{ post.url }}</link>
+				<guid isPermaLink="true">{{ site.url }}{{ site.baseurl }}{{ post.url }}</guid>
+			</item>
+		{% endfor %}
+	</channel>
+</rss>


### PR DESCRIPTION
uses `feed.xml` from https://github.com/snaptortoise/jekyll-rss-feeds
(slightly modified for `site.url` + `site.baseurl`)
