### PR TITLE
17.0.2 memory patch

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -36,6 +36,7 @@ import {enableScopeAPI} from 'shared/ReactFeatureFlags';
 // const randomKey = Math.random()
 //   .toString(36)
 //   .slice(2);
+// HACK: not so random anymore
 const randomKey = '';
 const internalInstanceKey = '__reactFiber$' + randomKey;
 const internalPropsKey = '__reactProps$' + randomKey;

--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -33,9 +33,10 @@ import {getParentSuspenseInstance} from './ReactDOMHostConfig';
 import invariant from 'shared/invariant';
 import {enableScopeAPI} from 'shared/ReactFeatureFlags';
 
-const randomKey = Math.random()
-  .toString(36)
-  .slice(2);
+// const randomKey = Math.random()
+//   .toString(36)
+//   .slice(2);
+const randomKey = '';
 const internalInstanceKey = '__reactFiber$' + randomKey;
 const internalPropsKey = '__reactProps$' + randomKey;
 const internalContainerInstanceKey = '__reactContainer$' + randomKey;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -1044,7 +1044,7 @@ function commitUnmount(
           } while (effect !== firstEffect);
         }
       }
-      return;
+      break;
     }
     case ClassComponent: {
       safelyDetachRef(current, nearestMountedAncestor);
@@ -1056,11 +1056,11 @@ function commitUnmount(
           nearestMountedAncestor,
         );
       }
-      return;
+      break;
     }
     case HostComponent: {
       safelyDetachRef(current, nearestMountedAncestor);
-      return;
+      break;
     }
     case HostPortal: {
       // TODO: this is recursive.
@@ -1076,7 +1076,7 @@ function commitUnmount(
       } else if (supportsPersistence) {
         emptyPortalContainer(current);
       }
-      return;
+      break;
     }
     case FundamentalComponent: {
       if (enableFundamentalAPI) {
@@ -1086,7 +1086,7 @@ function commitUnmount(
           current.stateNode = null;
         }
       }
-      return;
+      break;
     }
     case DehydratedFragment: {
       if (enableSuspenseCallback) {
@@ -1098,14 +1098,20 @@ function commitUnmount(
           }
         }
       }
-      return;
+      break;
     }
     case ScopeComponent: {
       if (enableScopeAPI) {
         safelyDetachRef(current, nearestMountedAncestor);
       }
-      return;
+      break;
     }
+  }
+
+  // Remove reference for GC
+  current.stateNode = null;
+  if (current.alternate != null) {
+    current.alternate.stateNode = null;
   }
 }
 
@@ -1460,6 +1466,8 @@ function unmountHostComponents(
     }
 
     if (node.tag === HostComponent || node.tag === HostText) {
+      // Save stateNode reference so commitUnmount can clear it.
+      const stateNode: Instance | TextInstance = node.stateNode;
       commitNestedUnmounts(
         finishedRoot,
         node,
@@ -1469,15 +1477,9 @@ function unmountHostComponents(
       // After all the children have unmounted, it is now safe to remove the
       // node from the tree.
       if (currentParentIsContainer) {
-        removeChildFromContainer(
-          ((currentParent: any): Container),
-          (node.stateNode: Instance | TextInstance),
-        );
+        removeChildFromContainer(((currentParent: any): Container), stateNode);
       } else {
-        removeChild(
-          ((currentParent: any): Instance),
-          (node.stateNode: Instance | TextInstance),
-        );
+        removeChild(((currentParent: any): Instance), stateNode);
       }
       // Don't visit children because we already visited them.
     } else if (enableFundamentalAPI && node.tag === FundamentalComponent) {

--- a/packages/react-reconciler/src/ReactFiberCommitWork.new.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.new.js
@@ -1060,6 +1060,23 @@ function commitUnmount(
     }
     case HostComponent: {
       safelyDetachRef(current, nearestMountedAncestor);
+      // HACK: detach fiber references from DOM
+      current.stateNode.__reactFiber$ = null;
+      current.stateNode.__reactProps$ = null;
+      current.stateNode.__reactContainer$ = null;
+      current.stateNode.__reactEvents$ = null;
+      current.stateNode.__reactListeners$ = null;
+      current.stateNode.__reactHandles$ = null;
+      break;
+    }
+    case HostText: {
+      // HACK: detach fiber references from DOM
+      current.stateNode.__reactFiber$ = null;
+      current.stateNode.__reactProps$ = null;
+      current.stateNode.__reactContainer$ = null;
+      current.stateNode.__reactEvents$ = null;
+      current.stateNode.__reactListeners$ = null;
+      current.stateNode.__reactHandles$ = null;
       break;
     }
     case HostPortal: {


### PR DESCRIPTION
Changes from https://github.com/discord/react/pull/1 applied to https://github.com/facebook/react/tree/17.0.2. Equivalent changes are included in React 18 so these patches will not be needed.

https://github.com/discord/react/commit/b0194a088a5186b55a6951c2b08702f26f6d5b58 has been merged upstream in https://github.com/facebook/react/pull/16115

`react-dom` package has been built on branch https://github.com/paulshen/react/tree/17.0.2-memory-patch-build

## Usage instructions

Update `package.json` with following

```json
{
  "react": "17.0.2",
  "react-dom": "paulshen/react#731ea24f22e78be9efd712594a52f310158d2e8b"
}
```